### PR TITLE
Fixes deleting and selecting/unselecting by always using the Speck.ID vs. the object ID

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,7 +36,7 @@
             } 
         },
         {
-            "name": "Run Rhino 7",
+            "name": "Run Rhino 7 (Mac)",
             "type": "rhino",
             "request": "launch",
             "preLaunchTask": "build-plugin",
@@ -46,6 +46,20 @@
             "console": "internalConsole",
             "env": {
                 "RHINO_PLUGIN_PATH": "${workspaceFolder}/Crash/bin/Debug/net48/Crash.rhp"
+            } 
+        },
+        {
+            "name": "Run Rhino 7 (Windows)",
+            "type": "clr",
+            "request": "launch",
+            "preLaunchTask": "build-plugin",
+            "program": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+            "args": [
+                "${workspaceFolder}\\Crash\\bin\\Debug\\net48\\Crash.rhp"
+            ],
+            "cwd": "${workspaceFolder}",
+            "console": "internalConsole",
+            "env": {
             } 
         }
 

--- a/Crash/Events/RemoveItem.cs
+++ b/Crash/Events/RemoveItem.cs
@@ -16,8 +16,9 @@ namespace Crash.Events
 
         internal static void Event(object sender, RhinoObjectEventArgs e)
         {
-            //TODO: if an item is removed, remove the item from the database
-            RequestManager.LocalClient?.Delete(e.ObjectId);
+            var id = LocalCache.GetSpeckId(e.TheObject);
+            if (id != null)
+                RequestManager.LocalClient?.Delete(id.Value);
         }
 
     }

--- a/Crash/Events/SelectAllItems.cs
+++ b/Crash/Events/SelectAllItems.cs
@@ -22,7 +22,11 @@ namespace Crash.Events
                 if (robj.IsLocked)
                     continue;
                 else
-                    RequestManager.LocalClient?.Unselect(robj.Id);
+                {
+                    var speckId = LocalCache.GetSpeckId(robj);
+                    if (speckId != null)
+                        RequestManager.LocalClient?.Unselect(speckId.Value);
+                }
 
             }
         }

--- a/Crash/Events/SelectItem.cs
+++ b/Crash/Events/SelectItem.cs
@@ -19,13 +19,14 @@ namespace Crash.Events
             {
                 if (robj.IsLocked)
                     continue;
+                var speckId = LocalCache.GetSpeckId(robj);
+                if (speckId == null)
+                    continue;
 
                 if(e.Selected)
-                {
-                    RequestManager.LocalClient?.Select(robj.Id);
-                }
+                    RequestManager.LocalClient?.Select(speckId.Value);
                 else
-                    RequestManager.LocalClient?.Unselect(robj.Id);
+                    RequestManager.LocalClient?.Unselect(speckId.Value);
 
             }
         }

--- a/Crash/Utilities/LocalCache.cs
+++ b/Crash/Utilities/LocalCache.cs
@@ -106,18 +106,29 @@ namespace Crash.Utilities
             SyncHost(rObj, speck);
         }
 
+        static string SpeckIdKey = "SPECKID";
+        
+        public static Guid? GetSpeckId(RhinoObject rObj)
+        {
+            if (rObj == null) return null;
+
+            if (rObj.UserDictionary.TryGetGuid(SpeckIdKey, out var key))
+                return key;
+            
+            return null;
+        }
+
         public static void SyncHost(RhinoObject rObj, Speck speck)
         {
             if (null == speck || rObj == null) return;
 
             // Data
-            string key = "SPECKID";
-            if (rObj.UserDictionary.TryGetGuid(key, out _))
+            if (rObj.UserDictionary.TryGetGuid(SpeckIdKey, out _))
             {
-                rObj.UserDictionary.Remove(key);
+                rObj.UserDictionary.Remove(SpeckIdKey);
             }
 
-            rObj.UserDictionary.Set(key, speck.Id);
+            rObj.UserDictionary.Set(SpeckIdKey, speck.Id);
 
             // Key/Key
             if (Instance._SpeckToRhino.ContainsKey(speck.Id))


### PR DESCRIPTION
# Description

This fixes issues deleting and selecting objects by always using the speck ID vs. the object ID.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally and using the https://crash.azurewebsites.net server.
