### PR TITLE
Fixes Undo/Redo

### DIFF
--- a/Crash/Commands/OpenSharedModel.cs
+++ b/Crash/Commands/OpenSharedModel.cs
@@ -11,6 +11,7 @@ using System.Threading;
 namespace Crash.Commands
 {
 
+    [CommandStyle(Style.DoNotRepeat | Style.NotUndoable)]
     public sealed class OpenSharedModel : Command
     {
 

--- a/Crash/Commands/Release.cs
+++ b/Crash/Commands/Release.cs
@@ -10,6 +10,10 @@ using System.Collections.Generic;
 namespace Crash.Commands
 {
 
+    /// <summary>
+    /// Command to Release 
+    /// </summary>
+    [CommandStyle(Style.DoNotRepeat | Style.NotUndoable)]
     public sealed class ReleaseCommand : Command
     {
 
@@ -18,10 +22,13 @@ namespace Crash.Commands
             Instance = this;
         }
 
+        /// <inheritdoc />
         public static ReleaseCommand Instance { get; private set; }
 
+        /// <inheritdoc />
         public override string EnglishName => "Release";
 
+        /// <inheritdoc />
         protected override Result RunCommand(RhinoDoc doc, RunMode mode)
         {
             // TODO : Wait for response for data integrity check

--- a/Crash/Commands/StartSharedModel.cs
+++ b/Crash/Commands/StartSharedModel.cs
@@ -14,11 +14,14 @@ using System.Xml.Linq;
 
 namespace Crash.Commands
 {
+
     /// <summary>
     /// Command to start the shared model
     /// </summary>
+    [CommandStyle(Style.DoNotRepeat | Style.NotUndoable)]
     public sealed class StartSharedModel : Command
     {
+
         /// <summary>
         /// Empty constructor
         /// </summary>
@@ -32,8 +35,10 @@ namespace Crash.Commands
         /// </summary>
         public static StartSharedModel Instance { get; private set; }
 
+        /// <inheritdoc />
         public override string EnglishName => "StartSharedModel";
-        
+
+        /// <inheritdoc />
         protected override Result RunCommand(RhinoDoc doc, RunMode mode)
         {
             if (RequestManager.LocalClient is object)

--- a/Crash/Events/AddItem.cs
+++ b/Crash/Events/AddItem.cs
@@ -20,7 +20,7 @@ namespace Crash.Events
             if (CrashInit.IsInit) return;
             if (LocalCache.SomeoneIsDone) return;
 
-            Speck speck = new Speck(e.ObjectId, User.CurrentUser.name, e.TheObject.Geometry.ToJSON(null));
+            Speck speck = new Speck(User.CurrentUser.name, e.TheObject.Geometry.ToJSON(null));
 
             LocalCache.SyncHost(e.TheObject, speck);
 

--- a/Crash/Events/RegisterEvents.cs
+++ b/Crash/Events/RegisterEvents.cs
@@ -23,6 +23,7 @@ namespace Crash.Events
 			RhinoDoc.SelectObjects += SelectItem.Event;
 			RhinoDoc.DeselectObjects += SelectItem.Event;
 			RhinoDoc.DeselectAllObjects += SelectAllItems.Event;
+			RhinoDoc.UndeleteRhinoObject += AddItem.Event;
 
 			// Crash
 			RequestManager.LocalClient.OnSelect += CrashSelect.OnSelect;

--- a/SpeckLib/Speck.cs
+++ b/SpeckLib/Speck.cs
@@ -44,10 +44,9 @@ namespace SpeckLib
             _stamp = DateTime.UtcNow;
         }
 
-        public Speck(Guid id, string owner, string? payload = null)
+        public Speck(string owner, string? payload = null)
+            : this()
         {
-            _id = id;
-            _stamp = DateTime.UtcNow;
             _owner = owner;
             Payload = payload;
         }


### PR DESCRIPTION
# Description
This PR fixes any issues with Undo/Redo, even for release and any other commands.

Fixed Undo / Redo.
- Added an UnDelete event to capture undo.
- Removed Guid for new speck. This prevents specks with duplicate IDs. Now Specks are always unique.

## Tests
- [x] Create a new element, move it, undo and redo that
- [x] Release elements, and then undo/redo that.
		This works quite nicely, even with many items released.
		On the creators machine the undo deletes elements from others (like delete does)
		Redo re-adds the elements, but they will need releasing again.
		This does also even delete items that are selected by other users. Something to look at

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
