### PR TITLE
Created Closed Shared Model Command

### DIFF
--- a/Crash/Commands/CloseSharedModel.cs
+++ b/Crash/Commands/CloseSharedModel.cs
@@ -1,0 +1,55 @@
+﻿using Crash.Utilities;
+
+using Rhino;
+using Rhino.Input;
+using Rhino.Commands;
+
+namespace Crash.Commands
+{
+    
+    public sealed class CloseSharedModel : Command
+    {
+
+        public CloseSharedModel()
+        {
+            Instance = this;
+        }
+
+        public static CloseSharedModel Instance { get; private set; }
+
+        public override string EnglishName => "CloseSharedModel";
+
+        protected override Result RunCommand(RhinoDoc doc, RunMode mode)
+        {
+            bool choice = true;
+            if (!_GetReleaseChoice(ref choice)) return Result.Cancel;
+
+            if (choice)
+            {
+                var task = RequestManager.LocalClient.Done();
+                if (!task.Wait(500))
+                {
+                    RhinoApp.WriteLine("Could not Connect to server, data will not be saved.");
+                }
+                else
+                {
+                    RhinoApp.WriteLine("Model closed and saved successfully");
+                }
+            }
+
+            RequestManager.ForceEndLocalClient();
+
+            return Result.Success;
+        }
+
+        private static bool _GetReleaseChoice(ref bool choice)
+        {
+            Result getUrl = RhinoGet.GetBool("Do you want to release URL", true,
+                                             "No Release", "Release", ref choice);
+
+            return getUrl == Result.Success;
+        }
+
+    }
+
+}

--- a/Crash/Utilities/RequestManager.cs
+++ b/Crash/Utilities/RequestManager.cs
@@ -1,4 +1,4 @@
-﻿using SpeckLib;
+using SpeckLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,7 +33,15 @@ namespace Crash.Utilities
 
                 client.StartAsync();
 
-            }
+        }
+
+        public static void ForceEndLocalClient()
+        {
+            Events.EventManagement.DeRegisterEvents();
+
+            if (null == LocalClient) return;
+
+            RequestManager.LocalClient.StopAsync();
         }
 
         /// <summary>

--- a/Crash/Utilities/RequestManager.cs
+++ b/Crash/Utilities/RequestManager.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 namespace Crash.Utilities
 {
+
     /// <summary>
     /// The request manager
     /// </summary>
@@ -32,7 +33,7 @@ namespace Crash.Utilities
                 Events.EventManagement.RegisterEvents();
 
                 client.StartAsync();
-
+            }
         }
 
         public static void ForceEndLocalClient()


### PR DESCRIPTION
# Description

Offers users a more official way to close a shared model they're in rather than their only option being to just exit Rhino.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update